### PR TITLE
Match documentation about docker image #539

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To run from a docker container, type:
 
 ```bash
 docker pull mozilla/ssh_scan
-docker run -it mozilla/ssh_scan -t sshscan.rubidus.com
+docker run -it --rm mozilla/ssh_scan /app/bin/ssh_scan -t sshscan.rubidus.com
 ```
 
 To install and run from source, type:


### PR DESCRIPTION
Fixed the documentation to work with the current docker image: #539
- Adding the path to binary otherwise it's not found 
-  Adding the --rm flag to remove the container after executing the task